### PR TITLE
Access MongoDB lasily. Wait jobs to stop gracefully.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,6 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-Start HorariumServer in Asp.NET Core application
-
-```csharp
-public void Configure(IApplicationBuilder app)
-{
-    //...
-    app.ApplicationServices.StartHorariumServer();
-    //...
-}
-```
-
 Inject interface ```IHorarium``` into Controller
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add nuget-package Horarium.AspNetCore
 dotnet add package Horarium.AspNetCore
 ```
 
-Add  ```Horarium```  in Asp.NET Core DI
+Add ```Horarium Server```. This regiters Horarium as a [hosted service](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services), so .Net core runtime automatically starts and gracefully stops Horarium.
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)

--- a/src/Horarium.AspNetCore/Horarium.AspNetCore.csproj
+++ b/src/Horarium.AspNetCore/Horarium.AspNetCore.csproj
@@ -15,6 +15,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Horarium.AspNetCore/HorariumServerHostedService.cs
+++ b/src/Horarium.AspNetCore/HorariumServerHostedService.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Horarium.Interfaces;
+using Microsoft.Extensions.Hosting;
+
+namespace Horarium.AspNetCore
+{
+    public class HorariumServerHostedService : IHostedService
+    {
+        private readonly HorariumServer _horariumServer;
+
+        public HorariumServerHostedService(IHorarium horarium)
+        {
+            _horariumServer = (HorariumServer) horarium;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _horariumServer.Start();
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return _horariumServer.Stop();
+        }
+    }
+}

--- a/src/Horarium.AspNetCore/RegistrationHorariumExtension.cs
+++ b/src/Horarium.AspNetCore/RegistrationHorariumExtension.cs
@@ -27,6 +27,8 @@ namespace Horarium.AspNetCore
                 return new HorariumServer(jobRepository, settings);
             });
 
+            service.AddHostedService<HorariumServerHostedService>();
+
             return service;
         }
         
@@ -50,12 +52,6 @@ namespace Horarium.AspNetCore
             });
 
             return service;
-        }
-
-        public static void StartHorariumServer(this IServiceProvider serviceProvider)
-        {
-            var server = (HorariumServer)serviceProvider.GetService<IHorarium>();
-            server.Start();
         }
 
         private static void PrepareSettings(HorariumSettings settings, IServiceProvider serviceProvider)

--- a/src/Horarium.Test/AspNetCore/RegistrationHorariumExtensionTest.cs
+++ b/src/Horarium.Test/AspNetCore/RegistrationHorariumExtensionTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Horarium.AspNetCore;
 using Horarium.Interfaces;
 using Horarium.Repository;
@@ -13,20 +14,14 @@ namespace Horarium.Test.AspNetCore
         [Fact]
         public void AddHorariumServer_DefaultSettings_ReplaceForAspNetCore()
         {
-            var serviceMock = new Mock<IServiceCollection>();
-
-            var service = serviceMock.Object;
-
-            ServiceDescriptor descriptor = null;
+            var service = new ServiceCollection();
 
             var settings = new HorariumSettings();
-
-            serviceMock.Setup(x => x.Add(It.IsAny<ServiceDescriptor>()))
-                .Callback<ServiceDescriptor>(x => descriptor = x);
 
             service.AddHorariumServer(Mock.Of<IJobRepository>(),
                 provider => settings);
 
+            var descriptor = service.Single(x => x.ServiceType == typeof(IHorarium));
             var horarium = descriptor.ImplementationFactory(Mock.Of<IServiceProvider>());
 
             Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
@@ -34,6 +29,8 @@ namespace Horarium.Test.AspNetCore
             Assert.Equal(typeof(JobScopeFactory), settings.JobScopeFactory.GetType());
             Assert.Equal(typeof(HorariumLogger), settings.Logger.GetType());
             Assert.Equal(typeof(HorariumServer), horarium.GetType());
+
+            Assert.Contains(service, x => x.ImplementationType == typeof(HorariumServerHostedService));
         }
 
         [Fact]

--- a/src/Horarium.Test/Mongo/MongoRepositoryFactoryTest.cs
+++ b/src/Horarium.Test/Mongo/MongoRepositoryFactoryTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Horarium.Mongo;
 using MongoDB.Driver;
 using Xunit;
@@ -21,6 +22,16 @@ namespace Horarium.Test.Mongo
             MongoUrl mongoUrl = null;
 
             Assert.Throws<ArgumentNullException>(() => MongoRepositoryFactory.Create(mongoUrl));
+        }
+
+        [Fact]
+        public async Task Create_WellFormedUrl_AccessMongoLazily()
+        {
+            const string stubMongoUrl = "mongodb://fake-url:27017/fake_database_name/?serverSelectionTimeoutMs=100";
+
+            var mongoRepository = MongoRepositoryFactory.Create(stubMongoUrl);
+
+            await Assert.ThrowsAsync<TimeoutException>(() => mongoRepository.GetJobStatistic());
         }
     }
 }

--- a/src/Horarium.Test/UncompletedTaskListTests.cs
+++ b/src/Horarium.Test/UncompletedTaskListTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading.Tasks;
+using Horarium.Handlers;
+using Xunit;
+
+namespace Horarium.Test
+{
+    public class UncompletedTaskListTests
+    {
+        private readonly UncompletedTaskList _uncompletedTaskList = new UncompletedTaskList();
+
+        [Fact]
+        public async Task Add_TaskWithAnyResult_KeepsTaskUntilCompleted()
+        {
+            var tcs1 = new TaskCompletionSource<bool>();
+            var tcs2 = new TaskCompletionSource<bool>();
+            var tcs3 = new TaskCompletionSource<bool>();
+
+            _uncompletedTaskList.Add(tcs1.Task);
+            _uncompletedTaskList.Add(tcs2.Task);
+            _uncompletedTaskList.Add(tcs3.Task);
+
+            Assert.Equal(3, _uncompletedTaskList.Count);
+
+            tcs1.SetResult(false);
+            await Task.Delay(TimeSpan.FromSeconds(1)); // give a chance to finish continuations
+            Assert.Equal(2, _uncompletedTaskList.Count);
+
+            tcs2.SetException(new ApplicationException());
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            Assert.Equal(1, _uncompletedTaskList.Count);
+
+            tcs3.SetCanceled();
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            Assert.Equal(0, _uncompletedTaskList.Count);
+        }
+
+        [Fact]
+        public async Task WhenAllCompleted_NoTasks_ReturnsCompletedTask()
+        {
+            // Act
+            var whenAll = _uncompletedTaskList.WhenAllCompleted();
+
+            // Assert
+            Assert.True(whenAll.IsCompletedSuccessfully);
+            await whenAll;
+        }
+
+        [Fact]
+        public async Task WhenAllCompleted_TaskNotCompleted_AwaitsUntilTaskCompleted()
+        {
+            // Arrange
+            var tcs = new TaskCompletionSource<bool>();
+            _uncompletedTaskList.Add(tcs.Task);
+
+            // Act
+            var whenAll = _uncompletedTaskList.WhenAllCompleted();
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(1)); // give a chance to finish any running tasks
+            Assert.False(whenAll.IsCompleted);
+
+            tcs.SetResult(false);
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            Assert.True(whenAll.IsCompletedSuccessfully);
+
+            await whenAll;
+        }
+
+        [Fact]
+        public async Task WhenAllCompleted_TaskFaulted_DoesNotThrow()
+        {
+            // Arrange
+            _uncompletedTaskList.Add(Task.FromException(new ApplicationException()));
+
+            // Act
+            var whenAll = _uncompletedTaskList.WhenAllCompleted();
+
+            await whenAll;
+        }
+    }
+}

--- a/src/Horarium/Handlers/UncompletedTaskList.cs
+++ b/src/Horarium/Handlers/UncompletedTaskList.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Horarium.Interfaces;
+
+namespace Horarium.Handlers
+{
+    public class UncompletedTaskList : IUncompletedTaskList
+    {
+        private readonly LinkedList<Task> _uncompletedTasks = new LinkedList<Task>();
+        private readonly object _lockObject = new object();
+
+        public int Count
+        {
+            get
+            {
+                lock (_lockObject) return _uncompletedTasks.Count;
+            }
+        }
+
+        public void Add(Task task)
+        {
+            lock (_lockObject)
+            {
+                _uncompletedTasks.AddLast(task);
+            }
+
+            task.ContinueWith((t, state) =>
+            {
+                lock (_lockObject)
+                {
+                    _uncompletedTasks.Remove(task);
+                }
+            }, CancellationToken.None, TaskScheduler.Default);
+        }
+
+        public async Task WhenAllCompleted()
+        {
+            Task[] tasksToAwait;
+            lock (_lockObject)
+            {
+                tasksToAwait = _uncompletedTasks.ToArray();
+            }
+
+            try
+            {
+                await Task.WhenAll(tasksToAwait);
+            }
+            catch
+            {
+                // We just want to have all task completed by now.
+                // Any possible exceptions must be handled in jobs.
+            }
+        }
+    }
+}

--- a/src/Horarium/Handlers/UncompletedTaskList.cs
+++ b/src/Horarium/Handlers/UncompletedTaskList.cs
@@ -21,18 +21,20 @@ namespace Horarium.Handlers
 
         public void Add(Task task)
         {
+            LinkedListNode<Task> linkedListNode;
+
             lock (_lockObject)
             {
-                _uncompletedTasks.AddLast(task);
+                linkedListNode = _uncompletedTasks.AddLast(task);
             }
 
             task.ContinueWith((t, state) =>
             {
                 lock (_lockObject)
                 {
-                    _uncompletedTasks.Remove(task);
+                    _uncompletedTasks.Remove((LinkedListNode<Task>) state);
                 }
-            }, CancellationToken.None, TaskScheduler.Default);
+            }, linkedListNode, CancellationToken.None);
         }
 
         public async Task WhenAllCompleted()

--- a/src/Horarium/HorariumServer.cs
+++ b/src/Horarium/HorariumServer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Horarium.Handlers;
 using Horarium.Interfaces;
 using Horarium.Repository;
@@ -15,8 +16,6 @@ namespace Horarium
         private readonly IAdderJobs _adderJobs;
 
         private readonly IJobRepository _jobRepository;
-
-        private readonly TimeSpan _timeoutStop = TimeSpan.FromSeconds(5);
 
         public HorariumServer(IJobRepository jobRepository)
             : this(jobRepository, new HorariumSettings())
@@ -36,13 +35,13 @@ namespace Horarium
             var executorJob = new ExecutorJob(_jobRepository, _adderJobs, _settings);
 
             _runnerJobs = new RunnerJobs(_jobRepository, _settings, _settings.JsonSerializerSettings, _settings.Logger,
-                executorJob);
+                executorJob, new UncompletedTaskList());
             _runnerJobs.Start();
         }
 
-        public void Stop()
+        public Task Stop()
         {
-            _runnerJobs.Stop().Wait(_timeoutStop);
+            return _runnerJobs.Stop();
         }
 
         public new void Dispose()

--- a/src/Horarium/Interfaces/IUncompletedTaskList.cs
+++ b/src/Horarium/Interfaces/IUncompletedTaskList.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace Horarium.Interfaces
+{
+    /// <summary>
+    /// Keeps references to a task until it is completed.
+    /// </summary>
+    public interface IUncompletedTaskList
+    {
+        /// <summary>
+        /// Adds new task to monitor.
+        /// </summary>
+        void Add(Task task);
+
+        /// <summary>
+        /// Returns task that will complete (with success) when all currently running tasks complete or fail.
+        /// </summary>
+        Task WhenAllCompleted();
+    }
+}


### PR DESCRIPTION
1. MongoRepository opens a connection immediately upon creation. When writing unit tests, this Startup.cs code needs editing to replace MongoRepository with a stub:
```c#
public void ConfigureServices(IServiceCollection services)
{
    //...
    services.AddHorariumServer(MongoRepositoryFactory.Create("mongodb://localhost:27017/horarium"));
    //...
}
```
This PR makes MongoRepository truly lazy, so Startup.cs can be covered with tests without plumbing.

2. When stopping application (SIGTERM / ctrl+c), Horarium does not await jobs to complete. Therefore a job state may not be saved to MongoDB and the job would execute again after application restart.
This PR implements IHostedService for Horarium. Since .NET core 2.1 [IHostedService ](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/multi-container-microservice-net-applications/background-tasks-with-ihostedservice)is a default way to do background work and to stop gracefully.
```c#
public interface IHostedService
{
     Task StartAsync(CancellationToken cancellationToken);
     Task StopAsync(CancellationToken cancellationToken);
}
``` 
`StopAsync()` stops scheduling next jobs and awaits currently uncompleted Tasks.
