### PR TITLE
Respect host's ShutdownTimeout (e.g. cancellation token) when stopping jobs

### DIFF
--- a/src/Horarium.AspNetCore/HorariumServerHostedService.cs
+++ b/src/Horarium.AspNetCore/HorariumServerHostedService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Horarium.Interfaces;
@@ -23,7 +24,7 @@ namespace Horarium.AspNetCore
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            return _horariumServer.Stop();
+            return _horariumServer.Stop(cancellationToken);
         }
     }
 }

--- a/src/Horarium.Test/RunnerJobTest.cs
+++ b/src/Horarium.Test/RunnerJobTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Newtonsoft.Json;
@@ -31,7 +32,7 @@ namespace Horarium.Test
 
             await Task.Delay(TimeSpan.FromSeconds(1));
 
-            await runnerJobs.Stop();
+            await runnerJobs.Stop(CancellationToken.None);
 
             jobRepositoryMock.Invocations.Clear();
 
@@ -129,7 +130,7 @@ namespace Horarium.Test
             // Act
             runnerJobs.Start();
             await Task.Delay(TimeSpan.FromSeconds(5));
-            await runnerJobs.Stop();
+            await runnerJobs.Stop(CancellationToken.None);
 
             // Assert
             uncompletedTaskList.Verify(x=>x.Add(It.IsAny<Task>()), Times.Once);
@@ -141,6 +142,7 @@ namespace Horarium.Test
             // Arrange
             var jobRepositoryMock = new Mock<IJobRepository>();
             var uncompletedTaskList = new Mock<IUncompletedTaskList>();
+            var cancellationToken = new CancellationTokenSource().Token;
 
             var settings = new HorariumSettings
             {
@@ -159,10 +161,10 @@ namespace Horarium.Test
             // Act
             runnerJobs.Start();
             await Task.Delay(TimeSpan.FromSeconds(1));
-            await runnerJobs.Stop();
+            await runnerJobs.Stop(cancellationToken);
 
             // Assert
-            uncompletedTaskList.Verify(x => x.WhenAllCompleted(), Times.Once);
+            uncompletedTaskList.Verify(x => x.WhenAllCompleted(cancellationToken), Times.Once);
         }
     }
 }

--- a/src/Horarium/Handlers/RunnerJobs.cs
+++ b/src/Horarium/Handlers/RunnerJobs.cs
@@ -45,7 +45,7 @@ namespace Horarium.Handlers
             _horariumLogger.Debug("Started RunnerJob...");
         }
 
-        public async Task Stop()
+        public async Task Stop(CancellationToken stopCancellationToken)
         {
             _cancelTokenSource.Cancel(false);
 
@@ -58,7 +58,7 @@ namespace Horarium.Handlers
                 //watcher был остановлен
             }
 
-            await _uncompletedTaskList.WhenAllCompleted();
+            await _uncompletedTaskList.WhenAllCompleted(stopCancellationToken);
 
             _horariumLogger.Debug("Stopped DeleterJob");
         }

--- a/src/Horarium/HorariumServer.cs
+++ b/src/Horarium/HorariumServer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Horarium.Handlers;
 using Horarium.Interfaces;
@@ -39,14 +40,14 @@ namespace Horarium
             _runnerJobs.Start();
         }
 
-        public Task Stop()
+        public Task Stop(CancellationToken stopCancellationToken)
         {
-            return _runnerJobs.Stop();
+            return _runnerJobs.Stop(stopCancellationToken);
         }
 
         public new void Dispose()
         {
-            Stop();
+            Stop(CancellationToken.None);
         }
     }
 }

--- a/src/Horarium/Interfaces/IRunnerJobs.cs
+++ b/src/Horarium/Interfaces/IRunnerJobs.cs
@@ -1,11 +1,17 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace Horarium.Interfaces
 {
     public interface IRunnerJobs
     {
         void Start();
-        Task Stop();
+
+        /// <summary>
+        /// Stops scheduling next jobs and awaits currently running jobs.
+        /// If <see cref="stopCancellationToken"></see> is cancelled, than abandons running jobs.
+        /// </summary>
+        Task Stop(CancellationToken stopCancellationToken);
 
     }
 }

--- a/src/Horarium/Interfaces/IUncompletedTaskList.cs
+++ b/src/Horarium/Interfaces/IUncompletedTaskList.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Horarium.Interfaces
@@ -15,6 +17,7 @@ namespace Horarium.Interfaces
         /// <summary>
         /// Returns task that will complete (with success) when all currently running tasks complete or fail.
         /// </summary>
-        Task WhenAllCompleted();
+        /// <param name="cancellationToken">If cancelled, throws <see cref="OperationCanceledException"/> immediately.</param>
+        Task WhenAllCompleted(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
We made a graceful stopping in #41. This PR adds respect to [ShutdownTimeout](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.1#shutdowntimeout-1) by using a cancellation token from `IHostedService.StopAsync()`. Thus Horarium will abandon awaiting jobs after the timeout. This way feels consistent with .Net core.
 