### PR TITLE
Conventions should not affect mongodb serialization

### DIFF
--- a/src/Horarium.Mongo/JobMongoModel.cs
+++ b/src/Horarium.Mongo/JobMongoModel.cs
@@ -32,40 +32,71 @@ namespace Horarium.Mongo
             };
         }
 
-        [BsonId] 
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
         public string JobId { get; set; }
 
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("JobKey")]
         public string JobKey { get; set; }
 
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("JobType")]
         public string JobType { get; set; }
 
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("JobParamType")]
         public string JobParamType { get; set; }
 
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("JobParam")]
         public string JobParam { get; set; }
 
+        [BsonRepresentation(BsonType.Int32)]
+        [BsonElement("Status")]
         public JobStatus Status { get; set; }
 
+        [BsonRepresentation(BsonType.Int32)]
+        [BsonElement("CountStarted")]
         public int CountStarted { get; set; }
 
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("ExecutedMachine")]
         public string ExecutedMachine { get; set; }
 
+        [BsonDateTimeOptions(Kind = DateTimeKind.Utc, DateOnly = false, Representation = BsonType.DateTime)]
+        [BsonElement("StartedExecuting")]
         public DateTime StartedExecuting { get; set; }
 
+        [BsonDateTimeOptions(Kind = DateTimeKind.Utc, DateOnly = false, Representation = BsonType.DateTime)]
+        [BsonElement("StartAt")]
         public DateTime StartAt { get; set; }
 
+        [BsonElement("NextJob")]
         public JobMongoModel NextJob { get; set; }
 
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("Error")]
         public string Error { get; set; }
 
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("Cron")]
         public string Cron { get; set; }
 
+        [BsonTimeSpanOptions(BsonType.String)]
+        [BsonElement("Delay")]
         public TimeSpan? Delay { get; set; }
 
         [BsonTimeSpanOptions(BsonType.Int64, TimeSpanUnits.Milliseconds)]
+        [BsonElement("ObsoleteInterval")]
         public TimeSpan ObsoleteInterval { get; set; }
-        
+
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("RepeatStrategy")]
         public string RepeatStrategy { get; set; }
-        
+
+        [BsonRepresentation(BsonType.Int32)]
+        [BsonElement("MaxRepeatCount")]
         public int MaxRepeatCount { get; set; }
 
         public static JobMongoModel CreateJobMongoModel(JobDb jobDb)

--- a/src/Horarium.Mongo/MongoRepositoryFactory.cs
+++ b/src/Horarium.Mongo/MongoRepositoryFactory.cs
@@ -9,7 +9,7 @@ namespace Horarium.Mongo
         public static IJobRepository Create(string connectionString)
         {
             if (string.IsNullOrEmpty(connectionString))
-                throw new ArgumentNullException("Connections string is empty");
+                throw new ArgumentNullException(nameof(connectionString), "Connection string is empty");
 
             var provider = new MongoClientProvider(connectionString);
             return new MongoRepository(provider);
@@ -18,7 +18,7 @@ namespace Horarium.Mongo
         public static IJobRepository Create(MongoUrl mongoUrl)
         {
             if (mongoUrl == null)
-                throw new ArgumentNullException("Connections string is empty");
+                throw new ArgumentNullException(nameof(mongoUrl), "mongoUrl is null");
 
             var provider = new MongoClientProvider(mongoUrl);
             return new MongoRepository(provider);

--- a/src/Horarium.Mongo/RecurrentJobSettingsMongo.cs
+++ b/src/Horarium.Mongo/RecurrentJobSettingsMongo.cs
@@ -1,4 +1,5 @@
 ﻿using Horarium.Repository;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Horarium.Mongo
@@ -17,10 +18,15 @@ namespace Horarium.Mongo
         }
         
         [BsonId]
+        [BsonRepresentation(BsonType.String)]
         public string JobKey { get; private set; }
 
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("JobType")]
         public string JobType { get; private set; }
-        
+
+        [BsonRepresentation(BsonType.String)]
+        [BsonElement("Cron")]
         public string Cron { get; private set; }
     }
 }

--- a/src/Horarium/Interfaces/IRunnerJobs.cs
+++ b/src/Horarium/Interfaces/IRunnerJobs.cs
@@ -9,7 +9,7 @@ namespace Horarium.Interfaces
 
         /// <summary>
         /// Stops scheduling next jobs and awaits currently running jobs.
-        /// If <see cref="stopCancellationToken"></see> is cancelled, than abandons running jobs.
+        /// If <see cref="stopCancellationToken"></see> is cancelled, then abandons running jobs.
         /// </summary>
         Task Stop(CancellationToken stopCancellationToken);
 


### PR DESCRIPTION
Assume an application that uses Horarium have code like this:
```c#
 ConventionRegistry.Register("EnumStringConvention",
                new ConventionPack {new EnumRepresentationConvention(BsonType.String),}, t => true);
```
Such code can be used to adjust the application's MongoDB document, but accidentally changes Horarium's internal representation of enum `Status`. Jobs serialized with different conventions are not compatible.

This behavior discovered after #41 lazy MongoDB access. With lazy MongoDB access, the app has time to register conventions. That leads to different serialization with lazy and without lazy access.

PR sets Horarium's field names and types explicitly to always match default conventions. 

Also, minor typos fixed.